### PR TITLE
patch piphack script versions of pip 19.1+

### DIFF
--- a/files/halite_gem/poise_python/resources/python_package.rb
+++ b/files/halite_gem/poise_python/resources/python_package.rb
@@ -42,18 +42,37 @@ if re.match(r'0\\.|1\\.|6\\.0', pip.__version__):
   sys.stderr.write('The python_package resource requires pip >= 6.1.0, currently '+pip.__version__+'\\n')
   sys.exit(1)
 
+# pip has shuffled around it's internals over the years so we gotta test where things are
 try:
   from pip.commands import InstallCommand
-  from pip.index import PackageFinder
-  from pip.req import InstallRequirement
+  cmd = InstallCommand()
 except ImportError:
-  # Pip 10 moved all internals to their own package.
-  from pip._internal.commands import InstallCommand
-  from pip._internal.index import PackageFinder
+  try:
+    from pip._internal.commands import InstallCommand
+    cmd = InstallCommand()
+  except ImportError:
+    from pip._internal.commands import create_command
+    cmd = create_command("install")
 
+try:
+  from pip.index import PackageFinder
+except ImportError:
+  try:
+    from pip._internal.index import PackageFinder
+  except ImportError:
+    from pip._internal.index.package_finder import PackageFinder
+
+try:
+  from pip.req import InstallRequirement
+  install_req_from_line = InstallRequirement.from_line
+except ImportError:
+  try:
+    from pip._internal.req import InstallRequirement
+    install_req_from_line = InstallRequirement.from_line
+  except ImportError:
+    from pip._internal.req.constructors import install_req_from_line
 
 packages = {}
-cmd = InstallCommand()
 options, args = cmd.parse_args(sys.argv[1:])
 with cmd._build_session(options) as session:
   if options.no_index:
@@ -71,20 +90,45 @@ with cmd._build_session(options) as session:
     finder_options['process_dependency_links'] = options.process_dependency_links
   if getattr(options, 'format_control', None):
     finder_options['format_control'] = options.format_control
-  finder = PackageFinder(**finder_options)
-  find_all = getattr(finder, 'find_all_candidates', getattr(finder, '_find_all_versions', None))
-  for arg in args:
+  try:
+    finder = PackageFinder(**finder_options)
+  except TypeError:
+    # need to use LinkCollector
     try:
-      from pip._internal.req.constructors import install_req_from_line
-      req = install_req_from_line(arg)
+      from pip._internal.collector import LinkCollector
     except ImportError:
-      from pip._internal.req import InstallRequirement
-      req = InstallRequirement.from_line(arg)
+      from pip._internal.index.collector import LinkCollector
+
+    from pip._internal.models.search_scope import SearchScope
+    from pip._internal.models.selection_prefs import SelectionPreferences
+
+    search_scope = SearchScope.create(
+      finder_options['find_links'], finder_options['index_urls']
+    )
+    collector = LinkCollector(session, search_scope)
+    selection_prefs = SelectionPreferences(
+      False, # allow_yanked
+      allow_all_prereleases=options.pre,
+      format_control=finder_options.get('format_control')
+    )
+    finder = PackageFinder.create(collector, selection_prefs)
+  find_all = getattr(finder, 'find_all_candidates', getattr(finder, '_find_all_versions', None))
+
+  def candidate_link(c, default=None):
+    return getattr(c, 'location', getattr(c, 'link', default))
+
+  for arg in args:
+    req = install_req_from_line(arg)
     found = finder.find_requirement(req, True)
     all_candidates = find_all(req.name)
-    candidate = [c for c in all_candidates if c.location == found]
+    candidate = [
+      c for c in all_candidates
+      if candidate_link(c) == candidate_link(found, default=found)
+    ]
     if candidate:
-      packages[candidate[0].project.lower()] = str(candidate[0].version)
+      c = candidate[0]
+      candidate_name = getattr(c, 'project', getattr(c, 'name', None)).lower()
+      packages[candidate_name] = c.version
 json.dump(packages, sys.stdout)
 EOH
 

--- a/files/halite_gem/poise_python/resources/python_package.rb
+++ b/files/halite_gem/poise_python/resources/python_package.rb
@@ -107,7 +107,7 @@ with cmd._build_session(options) as session:
     )
     collector = LinkCollector(session, search_scope)
     selection_prefs = SelectionPreferences(
-      False, # allow_yanked
+      allow_yanked=False,
       allow_all_prereleases=options.pre,
       format_control=finder_options.get('format_control')
     )
@@ -128,7 +128,7 @@ with cmd._build_session(options) as session:
     if candidate:
       c = candidate[0]
       candidate_name = getattr(c, 'project', getattr(c, 'name', None)).lower()
-      packages[candidate_name] = c.version
+      packages[candidate_name] = str(c.version)
 json.dump(packages, sys.stdout)
 EOH
 

--- a/files/halite_gem/poise_python/resources/python_runtime_pip.rb
+++ b/files/halite_gem/poise_python/resources/python_runtime_pip.rb
@@ -180,9 +180,6 @@ module PoisePython
           end
 
           Chef::Log.debug("[#{new_resource}] Installing pip #{new_resource.version} via itself")
-          if pip_version.to_i < 19
-            get_pip_url = 'https://s3.amazonaws.com/a1s-public-software-repository/get-pip.py'
-          end
           notifying_block do
             # Use pip to upgrade (or downgrade) itself.
             python_package 'pip' do


### PR DESCRIPTION
also removed a blurb that wasn't doing anything in `python_runtime_pip.rb`
tested on pip versions 20+ as well as 19 and 18. should still be careful reviewing this and testing though.